### PR TITLE
fix: invalid hex values

### DIFF
--- a/themes/catppuccin_latte.theme
+++ b/themes/catppuccin_latte.theme
@@ -38,7 +38,7 @@ theme[proc_box]="#1e66f5" #Blue
 theme[div_line]="#9CA0B0"
 
 # Temperature graph color (Green -> Yellow -> Red)
-theme[temp_start]="#40a02b
+theme[temp_start]="#40a02b"
 theme[temp_mid]="#df8e1d"
 theme[temp_end]="#d20f39"
 

--- a/themes/catppuccin_mocha.theme
+++ b/themes/catppuccin_mocha.theme
@@ -52,7 +52,7 @@ theme[free_start]="#cba6f7"
 theme[free_mid]="#b4befe"
 theme[free_end]="#89b4fa"
 
-# Mem/Disk cached meter (Sapphire -> Lavender) 
+# Mem/Disk cached meter (Sapphire -> Lavender)
 theme[cached_start]="#74c7ec"
 theme[cached_mid]="#89b4fa"
 theme[cached_end]="#b4befe"
@@ -74,8 +74,8 @@ theme[download_end]="#f38ba8"
 
 # Upload graph colors (Green -> Sky)
 theme[upload_start]="#a6e3a1"
-theme[upload_mid]="#94e2d5" 
-theme[upload_end]="#89dceb
+theme[upload_mid]="#94e2d5"
+theme[upload_end]="#89dceb"
 
 # Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
 theme[process_start]="#74C7EC"


### PR DESCRIPTION
Small typos are logged, like the following:

```
2023/06/07 (20:33:54) | ===> btop++ v.1.2.13
2023/06/07 (20:33:54) | ERROR: Invalid hex value: 40a02b
theme[temp_mid]=
```