### PR TITLE
build: integrate whiskers

### DIFF
--- a/btop.tera
+++ b/btop.tera
@@ -1,0 +1,91 @@
+---
+whiskers:
+  version: 2.0.0
+  matrix:
+    - flavor
+  filename: "themes/catppuccin_{{ flavor.identifier }}.theme"
+---
+{%- set palette = flavor.colors -%}
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#{{ palette.base.hex }}"
+
+# Main text color
+theme[main_fg]="#{{ palette.text.hex }}"
+
+# Title color for boxes
+theme[title]="#{{ palette.text.hex }}"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#{{ palette.blue.hex }}"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#{{ palette.surface1.hex }}"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#{{ palette.blue.hex }}"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#{{ palette.overlay1.hex }}"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#{{ palette.rosewater.hex }}"
+
+# Background color of the percentage meters
+theme[meter_bg]="#{{ palette.surface1.hex }}"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#{{ palette.rosewater.hex }}"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#{{ palette.mauve.hex }}" #Mauve
+theme[mem_box]="#{{ palette.green.hex }}" #Green
+theme[net_box]="#{{ palette.maroon.hex }}" #Maroon
+theme[proc_box]="#{{ palette.blue.hex }}" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#{{ palette.overlay0.hex }}"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#{{ palette.green.hex }}"
+theme[temp_mid]="#{{ palette.yellow.hex }}"
+theme[temp_end]="#{{ palette.red.hex }}"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#{{ palette.teal.hex }}"
+theme[cpu_mid]="#{{ palette.sapphire.hex }}"
+theme[cpu_end]="#{{ palette.lavender.hex }}"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#{{ palette.mauve.hex }}"
+theme[free_mid]="#{{ palette.lavender.hex }}"
+theme[free_end]="#{{ palette.blue.hex }}"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#{{ palette.sapphire.hex }}"
+theme[cached_mid]="#{{ palette.blue.hex }}"
+theme[cached_end]="#{{ palette.lavender.hex }}"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#{{ palette.peach.hex }}"
+theme[available_mid]="#{{ palette.maroon.hex }}"
+theme[available_end]="#{{ palette.red.hex }}"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#{{ palette.green.hex }}"
+theme[used_mid]="#{{ palette.teal.hex }}"
+theme[used_end]="#{{ palette.sky.hex }}"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#{{ palette.peach.hex }}"
+theme[download_mid]="#{{ palette.maroon.hex }}"
+theme[download_end]="#{{ palette.red.hex }}"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#{{ palette.green.hex }}"
+theme[upload_mid]="#{{ palette.teal.hex }}"
+theme[upload_end]="#{{ palette.sky.hex }}"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#{{ palette.sapphire.hex }}"
+theme[process_mid]="#{{ palette.lavender.hex }}"
+theme[process_end]="#{{ palette.mauve.hex }}"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers btop.tera

--- a/themes/catppuccin_frappe.theme
+++ b/themes/catppuccin_frappe.theme
@@ -2,31 +2,31 @@
 theme[main_bg]="#303446"
 
 # Main text color
-theme[main_fg]="#C6D0F5"
+theme[main_fg]="#c6d0f5"
 
 # Title color for boxes
-theme[title]="#C6D0F5"
+theme[title]="#c6d0f5"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#8CAAEE"
+theme[hi_fg]="#8caaee"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#51576D"
+theme[selected_bg]="#51576d"
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#8CAAEE"
+theme[selected_fg]="#8caaee"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#838BA7"
+theme[inactive_fg]="#838ba7"
 
 # Color of text appearing on top of graphs, i.e uptime and current network graph scaling
-theme[graph_text]="#F2D5CF"
+theme[graph_text]="#f2d5cf"
 
 # Background color of the percentage meters
-theme[meter_bg]="#51576D"
+theme[meter_bg]="#51576d"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#F2D5CF"
+theme[proc_misc]="#f2d5cf"
 
 # CPU, Memory, Network, Proc box outline colors
 theme[cpu_box]="#ca9ee6" #Mauve

--- a/themes/catppuccin_latte.theme
+++ b/themes/catppuccin_latte.theme
@@ -1,32 +1,32 @@
 # Main background, empty for terminal default, need to be empty if you want transparent background
-theme[main_bg]="#EFF1F5"
+theme[main_bg]="#eff1f5"
 
 # Main text color
-theme[main_fg]="#4C4F69"
+theme[main_fg]="#4c4f69"
 
 # Title color for boxes
-theme[title]="#4C4F69"
+theme[title]="#4c4f69"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#1E66F5"
+theme[hi_fg]="#1e66f5"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#BCC0CC"
+theme[selected_bg]="#bcc0cc"
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#1E66F5"
+theme[selected_fg]="#1e66f5"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#8C8FA1"
+theme[inactive_fg]="#8c8fa1"
 
 # Color of text appearing on top of graphs, i.e uptime and current network graph scaling
-theme[graph_text]="#DC8A78"
+theme[graph_text]="#dc8a78"
 
 # Background color of the percentage meters
-theme[meter_bg]="#BCC0CC"
+theme[meter_bg]="#bcc0cc"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#DC8A78"
+theme[proc_misc]="#dc8a78"
 
 # CPU, Memory, Network, Proc box outline colors
 theme[cpu_box]="#8839ef" #Mauve
@@ -35,7 +35,7 @@ theme[net_box]="#e64553" #Maroon
 theme[proc_box]="#1e66f5" #Blue
 
 # Box divider line and small boxes line color
-theme[div_line]="#9CA0B0"
+theme[div_line]="#9ca0b0"
 
 # Temperature graph color (Green -> Yellow -> Red)
 theme[temp_start]="#40a02b"
@@ -62,7 +62,6 @@ theme[available_start]="#fe640b"
 theme[available_mid]="#e64553"
 theme[available_end]="#d20f39"
 
-
 # Mem/Disk used meter (Green -> Sky)
 theme[used_start]="#40a02b"
 theme[used_mid]="#179299"
@@ -78,7 +77,7 @@ theme[upload_start]="#40a02b"
 theme[upload_mid]="#179299"
 theme[upload_end]="#04a5e5"
 
-# Process box color gradient for threads, mem and cpu usage (Sapphire -> Lavender-> Mauve)
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
 theme[process_start]="#209fb5"
 theme[process_mid]="#7287fd"
 theme[process_end]="#8839ef"

--- a/themes/catppuccin_macchiato.theme
+++ b/themes/catppuccin_macchiato.theme
@@ -1,32 +1,32 @@
 # Main background, empty for terminal default, need to be empty if you want transparent background
-theme[main_bg]="#24273A"
+theme[main_bg]="#24273a"
 
 # Main text color
-theme[main_fg]="#CAD3F5"
+theme[main_fg]="#cad3f5"
 
 # Title color for boxes
-theme[title]="#CAD3F5"
+theme[title]="#cad3f5"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#8AADF4"
+theme[hi_fg]="#8aadf4"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#494D64"
+theme[selected_bg]="#494d64"
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#8AADF4"
+theme[selected_fg]="#8aadf4"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#8087A2"
+theme[inactive_fg]="#8087a2"
 
 # Color of text appearing on top of graphs, i.e uptime and current network graph scaling
-theme[graph_text]="#F4DBD6"
+theme[graph_text]="#f4dbd6"
 
 # Background color of the percentage meters
-theme[meter_bg]="#494D64"
+theme[meter_bg]="#494d64"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#F4DBD6"
+theme[proc_misc]="#f4dbd6"
 
 # CPU, Memory, Network, Proc box outline colors
 theme[cpu_box]="#c6a0f6" #Mauve
@@ -35,7 +35,7 @@ theme[net_box]="#ee99a0" #Maroon
 theme[proc_box]="#8aadf4" #Blue
 
 # Box divider line and small boxes line color
-theme[div_line]="#6E738D"
+theme[div_line]="#6e738d"
 
 # Temperature graph color (Green -> Yellow -> Red)
 theme[temp_start]="#a6da95"

--- a/themes/catppuccin_mocha.theme
+++ b/themes/catppuccin_mocha.theme
@@ -1,32 +1,32 @@
 # Main background, empty for terminal default, need to be empty if you want transparent background
-theme[main_bg]="#1E1E2E"
+theme[main_bg]="#1e1e2e"
 
 # Main text color
-theme[main_fg]="#CDD6F4"
+theme[main_fg]="#cdd6f4"
 
 # Title color for boxes
-theme[title]="#CDD6F4"
+theme[title]="#cdd6f4"
 
 # Highlight color for keyboard shortcuts
-theme[hi_fg]="#89B4FA"
+theme[hi_fg]="#89b4fa"
 
 # Background color of selected item in processes box
-theme[selected_bg]="#45475A"
+theme[selected_bg]="#45475a"
 
 # Foreground color of selected item in processes box
-theme[selected_fg]="#89B4FA"
+theme[selected_fg]="#89b4fa"
 
 # Color of inactive/disabled text
-theme[inactive_fg]="#7F849C"
+theme[inactive_fg]="#7f849c"
 
 # Color of text appearing on top of graphs, i.e uptime and current network graph scaling
-theme[graph_text]="#F5E0DC"
+theme[graph_text]="#f5e0dc"
 
 # Background color of the percentage meters
-theme[meter_bg]="#45475A"
+theme[meter_bg]="#45475a"
 
 # Misc colors for processes box including mini cpu graphs, details memory graph and details status text
-theme[proc_misc]="#F5E0DC"
+theme[proc_misc]="#f5e0dc"
 
 # CPU, Memory, Network, Proc box outline colors
 theme[cpu_box]="#cba6f7" #Mauve
@@ -35,7 +35,7 @@ theme[net_box]="#eba0ac" #Maroon
 theme[proc_box]="#89b4fa" #Blue
 
 # Box divider line and small boxes line color
-theme[div_line]="#6C7086"
+theme[div_line]="#6c7086"
 
 # Temperature graph color (Green -> Yellow -> Red)
 theme[temp_start]="#a6e3a1"
@@ -78,6 +78,6 @@ theme[upload_mid]="#94e2d5"
 theme[upload_end]="#89dceb"
 
 # Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
-theme[process_start]="#74C7EC"
-theme[process_mid]="#89DCEB"
+theme[process_start]="#74c7ec"
+theme[process_mid]="#b4befe"
 theme[process_end]="#cba6f7"


### PR DESCRIPTION
This also fixes a minor bug where `sky` was used in place of `lavender` in the Mocha flavor.